### PR TITLE
qqnt@9.9.32.260716: Fix download URL (migrated to qqdl.gtimg.cn)

### DIFF
--- a/bucket/qqnt.json
+++ b/bucket/qqnt.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.9.30.260429",
+    "version": "9.9.32.260716",
     "description": "An instant messaging tool that gives you the best way to keep in touch with your friends and family, Build with Electron",
     "homepage": "https://im.qq.com",
     "license": {
@@ -8,16 +8,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.30_260429_x64_01.exe#/dl.7z",
-            "hash": "3d991ee6cc920a73272a72d6be934144f045852b86cc557ad45341f321565859"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.32/release/9d4083e2/QQ_9.9.32_260716_x64_01.exe#/dl.7z",
+            "hash": "685c989145381d9bc849948b836270111a8b6b8cebf2068ff158ac9d2324bc44"
         },
         "32bit": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.30_260429_x86_01.exe#/dl.7z",
-            "hash": "5bdfb927056ce1013eca1c9fa880870dfdcf480531befdd4ca487c8a8758bf00"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.32/release/9d4083e2/QQ_9.9.32_260716_x86_01.exe#/dl.7z",
+            "hash": "a27039b9c9fe9f59998b98a784bb743618990bbabde1582c776a174b94ef279f"
         },
         "arm64": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.30_260429_arm64_01.exe#/dl.7z",
-            "hash": "7425302a651278d07df3c89072a75bb618fb5da16f1a94ec465a66e77d31b1c1"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.32/release/9d4083e2/QQ_9.9.32_260716_arm64_01.exe#/dl.7z",
+            "hash": "76f9324dfa89bb6f21a46f826c50e472db3fda48d27f889964e6d21ad1c751dc"
         }
     },
     "installer": {
@@ -61,19 +61,19 @@
             "$url = $url -Replace [regex]::Escape($hostname), $ip",
             "Invoke-WebRequest -Uri $url -UseBasicParsing -Headers @{'Host' = $hostname} | Select-Object -ExpandProperty Content"
         ],
-        "regex": "QQNT/Windows/QQ_([\\d\\.]+)_([\\d]+)_x86_01.exe",
-        "replace": "${1}.${2}"
+        "regex": "QQNT/([\\d.]+)/release/([a-z0-9]+)/QQ_[\\d.]+_(\\d+)_x86_01.exe",
+        "replace": "${1}.${3}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x64_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match1/release/$match2/QQ_$match1_$match3_x64_01.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x86_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match1/release/$match2/QQ_$match1_$match3_x86_01.exe#/dl.7z"
             },
             "arm64": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_arm64_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match1/release/$match2/QQ_$match1_$match3_arm64_01.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
**Describe the changes**

QQ NT 下载链接变更，原 dldir1v6.qq.com 域名下的链接返回 404，已迁移至 qqdl.gtimg.cn。

- 更新版本从 9.9.30.260429 到 9.9.32.260716
- 更新所有架构（64bit/32bit/arm64）的下载 URL
- 更新对应 SHA256 哈希值
- 更新 checkver 正则和 autoupdate URL 模板以适配新链接结构

**Test steps**

1. 新下载链接已验证可访问（返回 HTTP 200）
2. 三个架构的 SHA256 哈希均基于实际下载文件计算
3. 运行 checkver 可正确匹配新版号

Closes N/A