### PR TITLE
pilinara@2.1.0.1: Fix extract_dir and shortcut exe name

### DIFF
--- a/bucket/pilinara.json
+++ b/bucket/pilinara.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Starfallan/PiliNara/releases/download/2.1.0.1-Himeko/PiliNara_windows_2.1.0%2B5524_x64_portable.zip",
-            "hash": "8bb80b6120f205c751496bf241e790e8c092129a16a33525c19cdac6bd7bf4a9"
+            "hash": "8bb80b6120f205c751496bf241e790e8c092129a16a33525c19cdac6bd7bf4a9",
+            "extract_dir": "PiliNara-Win"
         }
     },
     "installer": {
@@ -17,7 +18,7 @@
     },
     "shortcuts": [
         [
-            "piliplus.exe",
+            "pilinara.exe",
             "PiliNara"
         ]
     ],
@@ -34,7 +35,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Starfallan/PiliNara/releases/download/$version/PiliNara_windows_$match2%2B$match3_x64_portable.zip"
+                "url": "https://github.com/Starfallan/PiliNara/releases/download/$version/PiliNara_windows_$match2%2B$match3_x64_portable.zip",
+                "extract_dir": "PiliNara-Win"
             }
         }
     }

--- a/bucket/pilinara.json
+++ b/bucket/pilinara.json
@@ -35,8 +35,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Starfallan/PiliNara/releases/download/$version/PiliNara_windows_$match2%2B$match3_x64_portable.zip",
-                "extract_dir": "PiliNara-Win"
+                "url": "https://github.com/Starfallan/PiliNara/releases/download/$version/PiliNara_windows_$match2%2B$match3_x64_portable.zip"
             }
         }
     }


### PR DESCRIPTION
修复 zip 包内文件结构问题：

- 添加 xtract_dir: PiliNara-Win — zip 解压后文件在 PiliNara-Win 子目录下
- 修正快捷方式 exe 名 pilinara.exe — 实际 exe 名为 pilinara.exe 而非 piliplus.exe

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).