### PR TITLE
fluentcleaner-classic: Add version 26.07.04

### DIFF
--- a/bucket/fluentcleaner-classic.json
+++ b/bucket/fluentcleaner-classic.json
@@ -1,0 +1,25 @@
+{
+    "version": "26.07.04",
+    "description": "FluentCleaner Classic - Lightweight Windows system cleaning tool built with .NET Framework 4.8 and WinForms.",
+    "homepage": "https://github.com/builtbybel/FluentCleaner",
+    "license": "MIT",
+    "url": "https://github.com/builtbybel/FluentCleaner/releases/download/26.07.04/FluentCleaner-Classic-net48.zip",
+    "hash": "736e19d7622dfe0f95b7b879be8ca54736550de3b828aafb0b27392945d94c75",
+    "shortcuts": [
+        [
+            "FCleaner.exe",
+            "FluentCleaner Classic"
+        ]
+    ],
+    "persist": "settings.json",
+    "pre_install": [
+        "if (!(Test-Path \"$dir\\settings.json\") -or !(Get-Item \"$dir\\settings.json\").Length) {",
+        "    New-Item \"$dir\\settings.json\" -ItemType File -Force | Out-Null",
+        "    Set-Content -Path \"$dir\\settings.json\" -Value '{}'",
+        "}"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/builtbybel/FluentCleaner/releases/download/$version/FluentCleaner-Classic-net48.zip"
+    }
+}


### PR DESCRIPTION
FluentCleaner Classic - Lightweight Windows system cleaning tool built with .NET Framework 4.8 and WinForms.

- Portable mode via persisted \settings.json\
- Disabled auto-update (no built-in updater found)
- Tested with \checkver.ps1\ - version 26.07.04 detected

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).