### PR TITLE
deepseek-harness-desktop: Add version 2.0.1

### DIFF
--- a/bucket/deepseek-harness-desktop.json
+++ b/bucket/deepseek-harness-desktop.json
@@ -1,0 +1,44 @@
+{
+    "version": "2.0.1",
+    "description": "DSH Desktop: a modern desktop client for the DeepSeek Harness (DSH) plugin ecosystem.",
+    "homepage": "https://dshdesktop.cn",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/anywhere-labs/deepseek-harness-desktop/releases/download/v2.0.1/DSH-Desktop-2.0.1-x64-Setup.exe#/dl.7z",
+            "hash": "f749367ba970b6964c766d2134084e326dd50fad71cffda27b2081fbaec39552"
+        }
+    },
+    "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.zip\" \"$dir\"",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
+            ". \"$bucketsdir\\$bucket\\bin\\utils.ps1\"",
+            "New-PersistDirectory \"$env:APPDATA\\DSH Desktop\" \"$persist_dir\\AppData\" -Migrate",
+            "New-PersistDirectory \"$env:USERPROFILE\\.dsh\" \"$persist_dir\\USERPROFILE\\.dsh\" -Migrate"
+        ]
+    },
+    "shortcuts": [
+        [
+            "DSH Desktop.exe",
+            "DSH Desktop"
+        ]
+    ],
+    "pre_uninstall": [
+        "$bucket = $install.bucket",
+        ". \"$bucketsdir\\$bucket\\bin\\utils.ps1\"",
+        "Stop-App",
+        "Remove-Junction \"$env:APPDATA\\DSH Desktop\"",
+        "Remove-Junction \"$env:USERPROFILE\\.dsh\""
+    ],
+    "checkver": {
+        "github": "https://github.com/anywhere-labs/deepseek-harness-desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/anywhere-labs/deepseek-harness-desktop/releases/download/v$version/DSH-Desktop-$version-x64-Setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #100

Add [DeepSeek Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 2.0.1 (DSH Desktop), an Electron-based desktop client for the DeepSeek Harness (DSH) plugin ecosystem.

- Uses the existing electron-builder NSIS pattern: extract `$PLUGINSDIR\app-64.zip` in `pre_install`, remove installer leftovers
- Persists `%APPDATA%\DSH Desktop` and `%USERPROFILE%\.dsh`; existing data is migrated and junctioned to the Scoop persist dir
- Stops running app processes and removes junctions on uninstall

Tested:

- `.\bin\formatjson.ps1 deepseek-harness-desktop`
- Manifest schema validation: 0 errors
- `.\bin\checkver.ps1 -App deepseek-harness-desktop` resolves 2.0.1
- Isolated Scoop test install and `scoop uninstall deepseek-harness-desktop -p`: no leftover junctions, shortcuts, or temp directories

- [x] I have read the [Contributing Guide](/CONTRIBUTING.md).